### PR TITLE
Stop spammer if faucet outputs are not available

### DIFF
--- a/main.go
+++ b/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"flag"
 	"fmt"
 
@@ -23,6 +24,7 @@ const (
 
 func main() {
 	help := parseFlags()
+	ctx := context.Background()
 
 	if help {
 		fmt.Printf("Usage of the Evil Spammer tool, provide the first argument for the selected mode:\n"+
@@ -62,25 +64,25 @@ func main() {
 	// run selected test scenario
 	switch Script {
 	case ScriptInteractive:
-		interactive.Run()
+		interactive.Run(ctx)
 	case ScriptSpammer:
 		dispatcher := programs.NewDispatcher(accWallet)
-		dispatcher.RunSpam(&customSpamParams)
+		dispatcher.RunSpam(ctx, &customSpamParams)
 	case ScriptAccounts:
-		accountsSubcommands(accWallet, accountsSubcommandsFlags)
+		accountsSubcommands(ctx, accWallet, accountsSubcommandsFlags)
 	default:
 		log.Warnf("Unknown parameter for script, possible values: interactive, spammer, accounts")
 	}
 }
 
-func accountsSubcommands(wallet *accountwallet.AccountWallet, subcommands []accountwallet.AccountSubcommands) {
+func accountsSubcommands(ctx context.Context, wallet *accountwallet.AccountWallet, subcommands []accountwallet.AccountSubcommands) {
 	for _, sub := range subcommands {
-		accountsSubcommand(wallet, sub)
+		accountsSubcommand(ctx, wallet, sub)
 	}
 }
 
 //nolint:all,forcetypassert
-func accountsSubcommand(wallet *accountwallet.AccountWallet, sub accountwallet.AccountSubcommands) {
+func accountsSubcommand(ctx context.Context, wallet *accountwallet.AccountWallet, sub accountwallet.AccountSubcommands) {
 	switch sub.Type() {
 	case accountwallet.OperationCreateAccount:
 		log.Infof("Run subcommand: %s, with parametetr set: %v", accountwallet.OperationCreateAccount.String(), sub)
@@ -91,7 +93,7 @@ func accountsSubcommand(wallet *accountwallet.AccountWallet, sub accountwallet.A
 			return
 		}
 
-		accountID, err := wallet.CreateAccount(params)
+		accountID, err := wallet.CreateAccount(ctx, params)
 		if err != nil {
 			log.Errorf("Type assertion error: creating account: %v", err)
 
@@ -109,7 +111,7 @@ func accountsSubcommand(wallet *accountwallet.AccountWallet, sub accountwallet.A
 			return
 		}
 
-		err := wallet.DestroyAccount(params)
+		err := wallet.DestroyAccount(ctx, params)
 		if err != nil {
 			log.Errorf("Error destroying account: %v", err)
 

--- a/pkg/accountwallet/commands.go
+++ b/pkg/accountwallet/commands.go
@@ -1,6 +1,7 @@
 package accountwallet
 
 import (
+	"context"
 	"crypto/ed25519"
 	"fmt"
 	"time"
@@ -13,19 +14,19 @@ import (
 )
 
 // CreateAccount creates an implicit account and immediately transition it to a regular account.
-func (a *AccountWallet) CreateAccount(params *CreateAccountParams) (iotago.AccountID, error) {
+func (a *AccountWallet) CreateAccount(ctx context.Context, params *CreateAccountParams) (iotago.AccountID, error) {
 	if params.Implicit {
-		return a.createAccountImplicitly(params)
+		return a.createAccountImplicitly(ctx, params)
 	}
 
 	return a.createAccountWithFaucet(params)
 }
 
-func (a *AccountWallet) createAccountImplicitly(params *CreateAccountParams) (iotago.AccountID, error) {
+func (a *AccountWallet) createAccountImplicitly(ctx context.Context, params *CreateAccountParams) (iotago.AccountID, error) {
 	// An implicit account has an implicitly defined Block Issuer Key, corresponding to the address itself.
 	// Thus, implicit accounts can issue blocks by signing them with the private key corresponding to the public key
 	// from which the Implicit Account Creation Address was derived.
-	implicitAccountOutput, privateKey, err := a.getFunds(iotago.AddressImplicitAccountCreation)
+	implicitAccountOutput, privateKey, err := a.getFunds(ctx, iotago.AddressImplicitAccountCreation)
 	if err != nil {
 		return iotago.EmptyAccountID, ierrors.Wrap(err, "Failed to create account")
 	}
@@ -124,8 +125,8 @@ func (a *AccountWallet) getAddress(addressType iotago.AddressType) (iotago.Direc
 	return receiverAddr, privKey, newIndex
 }
 
-func (a *AccountWallet) DestroyAccount(params *DestroyAccountParams) error {
-	return a.destroyAccount(params.AccountAlias)
+func (a *AccountWallet) DestroyAccount(ctx context.Context, params *DestroyAccountParams) error {
+	return a.destroyAccount(ctx, params.AccountAlias)
 }
 
 func (a *AccountWallet) ListAccount() error {

--- a/pkg/accountwallet/faucet.go
+++ b/pkg/accountwallet/faucet.go
@@ -22,13 +22,13 @@ const (
 	FaucetAccountAlias = "faucet"
 )
 
-func (a *AccountWallet) RequestBlockBuiltData(clt *nodeclient.Client, issuerID iotago.AccountID) (*apimodels.CongestionResponse, *apimodels.IssuanceBlockHeaderResponse, iotago.Version, error) {
-	congestionResp, err := clt.Congestion(context.Background(), issuerID)
+func (a *AccountWallet) RequestBlockBuiltData(ctx context.Context, clt *nodeclient.Client, issuerID iotago.AccountID) (*apimodels.CongestionResponse, *apimodels.IssuanceBlockHeaderResponse, iotago.Version, error) {
+	congestionResp, err := clt.Congestion(ctx, issuerID)
 	if err != nil {
 		return nil, nil, 0, ierrors.Wrapf(err, "failed to get congestion data for issuer %s", issuerID.ToHex())
 	}
 
-	issuerResp, err := clt.BlockIssuance(context.Background(), congestionResp.Slot)
+	issuerResp, err := clt.BlockIssuance(ctx, congestionResp.Slot)
 	if err != nil {
 		return nil, nil, 0, ierrors.Wrap(err, "failed to get block issuance data")
 	}
@@ -38,13 +38,13 @@ func (a *AccountWallet) RequestBlockBuiltData(clt *nodeclient.Client, issuerID i
 	return congestionResp, issuerResp, version, nil
 }
 
-func (a *AccountWallet) RequestFaucetFunds(clt models.Client, receiveAddr iotago.Address) (*models.Output, error) {
-	err := clt.RequestFaucetFunds(receiveAddr)
+func (a *AccountWallet) RequestFaucetFunds(ctx context.Context, clt models.Client, receiveAddr iotago.Address) (*models.Output, error) {
+	err := clt.RequestFaucetFunds(ctx, receiveAddr)
 	if err != nil {
 		return nil, ierrors.Wrap(err, "failed to request funds from faucet")
 	}
 
-	outputID, outputStruct, err := utils.AwaitAddressUnspentOutputToBeAccepted(clt, receiveAddr)
+	outputID, outputStruct, err := utils.AwaitAddressUnspentOutputToBeAccepted(ctx, clt, receiveAddr)
 	if err != nil {
 		return nil, ierrors.Wrap(err, "failed to await faucet funds")
 	}
@@ -58,15 +58,15 @@ func (a *AccountWallet) RequestFaucetFunds(clt models.Client, receiveAddr iotago
 	}, nil
 }
 
-func (a *AccountWallet) PostWithBlock(clt models.Client, payload iotago.Payload, issuer mock.Account, congestionResp *apimodels.CongestionResponse, issuerResp *apimodels.IssuanceBlockHeaderResponse, version iotago.Version, strongParents ...iotago.BlockID) (iotago.BlockID, error) {
-	signedBlock, err := a.CreateBlock(payload, issuer, congestionResp, issuerResp, version, strongParents...)
+func (a *AccountWallet) PostWithBlock(ctx context.Context, clt models.Client, payload iotago.Payload, issuer mock.Account, congestionResp *apimodels.CongestionResponse, issuerResp *apimodels.IssuanceBlockHeaderResponse, version iotago.Version, strongParents ...iotago.BlockID) (iotago.BlockID, error) {
+	signedBlock, err := a.CreateBlock(ctx, payload, issuer, congestionResp, issuerResp, version, strongParents...)
 	if err != nil {
 		log.Errorf("failed to create block: %s", err)
 
 		return iotago.EmptyBlockID, err
 	}
 
-	blockID, err := clt.PostBlock(signedBlock)
+	blockID, err := clt.PostBlock(ctx, signedBlock)
 	if err != nil {
 		log.Errorf("failed to post block: %s", err)
 
@@ -76,13 +76,13 @@ func (a *AccountWallet) PostWithBlock(clt models.Client, payload iotago.Payload,
 	return blockID, nil
 }
 
-func (a *AccountWallet) CreateBlock(payload iotago.Payload, issuer mock.Account, congestionResp *apimodels.CongestionResponse, issuerResp *apimodels.IssuanceBlockHeaderResponse, version iotago.Version, strongParents ...iotago.BlockID) (*iotago.Block, error) {
+func (a *AccountWallet) CreateBlock(ctx context.Context, payload iotago.Payload, issuer mock.Account, congestionResp *apimodels.CongestionResponse, issuerResp *apimodels.IssuanceBlockHeaderResponse, version iotago.Version, strongParents ...iotago.BlockID) (*iotago.Block, error) {
 	issuingTime := time.Now()
 	issuingSlot := a.client.LatestAPI().TimeProvider().SlotFromTime(issuingTime)
 	apiForSlot := a.client.APIForSlot(issuingSlot)
 	if congestionResp == nil {
 		var err error
-		congestionResp, err = a.client.GetCongestion(issuer.ID())
+		congestionResp, err = a.client.GetCongestion(ctx, issuer.ID())
 		if err != nil {
 			return nil, ierrors.Wrap(err, "failed to get congestion data")
 		}
@@ -162,7 +162,8 @@ func newFaucet(clt models.Client, faucetParams *faucetParams) (*faucet, error) {
 }
 
 func (f *faucet) getGenesisOutputFromIndexer(clt models.Client, faucetAddr iotago.DirectUnlockableAddress) (iotago.Output, iotago.OutputID, iotago.BaseToken, error) {
-	indexer, err := clt.Indexer()
+	ctx := context.Background()
+	indexer, err := clt.Indexer(ctx)
 	if err != nil {
 		log.Errorf("account wallet failed due to failure in connecting to indexer")
 

--- a/pkg/evilwallet/output_manager.go
+++ b/pkg/evilwallet/output_manager.go
@@ -1,6 +1,7 @@
 package evilwallet
 
 import (
+	"context"
 	"sync"
 
 	"go.uber.org/atomic"
@@ -100,7 +101,7 @@ func (o *OutputManager) IssuerSolidOutIDMap(issuer string, outputID iotago.Outpu
 }
 
 // Track the confirmed statuses of the given outputIDs, it returns true if all of them are confirmed.
-func (o *OutputManager) Track(outputIDs ...iotago.OutputID) (allConfirmed bool) {
+func (o *OutputManager) Track(ctx context.Context, outputIDs ...iotago.OutputID) (allConfirmed bool) {
 	var (
 		wg                     sync.WaitGroup
 		unconfirmedOutputFound atomic.Bool
@@ -112,7 +113,7 @@ func (o *OutputManager) Track(outputIDs ...iotago.OutputID) (allConfirmed bool) 
 		go func(id iotago.OutputID, clt models.Client) {
 			defer wg.Done()
 
-			if !utils.AwaitOutputToBeAccepted(clt, id) {
+			if !utils.AwaitOutputToBeAccepted(ctx, clt, id) {
 				unconfirmedOutputFound.Store(true)
 			}
 		}(ID, o.connector.GetClient())
@@ -141,7 +142,7 @@ func (o *OutputManager) createOutputFromAddress(w *Wallet, addr *iotago.Ed25519A
 }
 
 // AddOutput adds existing output from wallet w to the OutputManager.
-func (o *OutputManager) AddOutput(w *Wallet, output *models.Output) *models.Output {
+func (o *OutputManager) AddOutput(ctx context.Context, w *Wallet, output *models.Output) *models.Output {
 	idx := w.AddrIndexMap(output.Address.String())
 	out := &models.Output{
 		Address:      output.Address,
@@ -154,7 +155,7 @@ func (o *OutputManager) AddOutput(w *Wallet, output *models.Output) *models.Outp
 	if w.walletType == Reuse {
 		go func(clt models.Client, wallet *Wallet, outputID iotago.OutputID) {
 			// Reuse wallet should only keep accepted outputs
-			accepted := utils.AwaitOutputToBeAccepted(clt, outputID)
+			accepted := utils.AwaitOutputToBeAccepted(ctx, clt, outputID)
 			if !accepted {
 				o.log.Errorf("Output %s not accepted in time", outputID.String())
 
@@ -178,13 +179,13 @@ func (o *OutputManager) AddOutput(w *Wallet, output *models.Output) *models.Outp
 
 // GetOutput returns the Output of the given outputID.
 // Firstly checks if output can be retrieved by outputManager from wallet, if not does an API call.
-func (o *OutputManager) GetOutput(outputID iotago.OutputID) (output *models.Output) {
+func (o *OutputManager) GetOutput(ctx context.Context, outputID iotago.OutputID) (output *models.Output) {
 	output = o.getOutputFromWallet(outputID)
 
 	// get output info via web api
 	if output == nil {
 		clt := o.connector.GetClient()
-		out := clt.GetOutput(outputID)
+		out := clt.GetOutput(ctx, outputID)
 		if out == nil {
 			return nil
 		}
@@ -218,7 +219,7 @@ func (o *OutputManager) getOutputFromWallet(outputID iotago.OutputID) (output *m
 }
 
 // AwaitWalletOutputsToBeConfirmed awaits for all outputs in the wallet are confirmed.
-func (o *OutputManager) AwaitWalletOutputsToBeConfirmed(wallet *Wallet) {
+func (o *OutputManager) AwaitWalletOutputsToBeConfirmed(ctx context.Context, wallet *Wallet) {
 	wg := sync.WaitGroup{}
 	for _, output := range wallet.UnspentOutputs() {
 		wg.Add(1)
@@ -232,14 +233,14 @@ func (o *OutputManager) AwaitWalletOutputsToBeConfirmed(wallet *Wallet) {
 		go func(outs iotago.OutputIDs) {
 			defer wg.Done()
 
-			o.Track(outs...)
+			o.Track(ctx, outs...)
 		}(outs)
 	}
 	wg.Wait()
 }
 
 // AwaitTransactionsAcceptance awaits for transaction confirmation and updates wallet with outputIDs.
-func (o *OutputManager) AwaitTransactionsAcceptance(txIDs ...iotago.TransactionID) {
+func (o *OutputManager) AwaitTransactionsAcceptance(ctx context.Context, txIDs ...iotago.TransactionID) {
 	wg := sync.WaitGroup{}
 	semaphore := make(chan bool, 1)
 	txLeft := atomic.NewInt64(int64(len(txIDs)))
@@ -254,7 +255,7 @@ func (o *OutputManager) AwaitTransactionsAcceptance(txIDs ...iotago.TransactionI
 				<-semaphore
 			}()
 
-			confirmationState, err := utils.AwaitTransactionToBeAccepted(clt, txID)
+			confirmationState, err := utils.AwaitTransactionToBeAccepted(ctx, clt, txID)
 			txLeft.Dec()
 			if err != nil {
 				o.log.Errorf("Error awaiting transaction %s to be accepted: %s", txID.String(), err)

--- a/pkg/evilwallet/wallets.go
+++ b/pkg/evilwallet/wallets.go
@@ -3,8 +3,6 @@ package evilwallet
 import (
 	"go.uber.org/atomic"
 
-	"github.com/iotaledger/evil-tools/pkg/models"
-	"github.com/iotaledger/hive.go/ierrors"
 	"github.com/iotaledger/hive.go/runtime/syncutils"
 )
 
@@ -109,15 +107,6 @@ func (w *Wallets) addReuseWallet(wallet *Wallet) {
 	w.reuseWallets[wallet.ID] = false
 }
 
-// GetUnspentOutput gets first found unspent output for a given walletType.
-func (w *Wallets) GetUnspentOutput(wallet *Wallet) *models.Output {
-	if wallet == nil {
-		return nil
-	}
-
-	return wallet.GetUnspentOutput()
-}
-
 // isFaucetWalletAvailable checks if there is any faucet wallet left.
 func (w *Wallets) isFaucetWalletAvailable() bool {
 	return len(w.faucetWallets) > 0
@@ -130,15 +119,14 @@ func (w *Wallets) freshWallet() (*Wallet, error) {
 	defer w.mu.Unlock()
 
 	if !w.isFaucetWalletAvailable() {
-
-		return nil, ierrors.New("no faucet wallets available, need to request more funds")
+		return nil, NoFreshOutputsAvailable
 	}
 
 	wallet := w.wallets[w.faucetWallets[0]]
 	if wallet.IsEmpty() {
 		w.removeFreshWallet()
 		if !w.isFaucetWalletAvailable() {
-			return nil, ierrors.New("no faucet wallets available, need to request more funds")
+			return nil, NoFreshOutputsAvailable
 		}
 
 		wallet = w.wallets[w.faucetWallets[0]]

--- a/pkg/models/connector.go
+++ b/pkg/models/connector.go
@@ -73,7 +73,7 @@ func NewWebClients(urls []string, faucetURL string, setters ...options.Option[We
 			return nil
 		}
 
-		if _, err := clients[i].client.Indexer(context.Background()); err == nil {
+		if _, err := clients[i].client.Indexer(context.TODO()); err == nil {
 			indexers = append(indexers, clients[i])
 		}
 	}
@@ -100,7 +100,7 @@ func (c *WebClients) ServersStatuses() ServerInfos {
 
 // ServerStatus retrieves the connected server status.
 func (c *WebClients) ServerStatus(cltIdx int) (status *ServerInfo, err error) {
-	response, err := c.clients[cltIdx].client.Info(context.Background())
+	response, err := c.clients[cltIdx].client.Info(context.TODO())
 	if err != nil {
 		return nil, err
 	}
@@ -197,29 +197,29 @@ func (c *WebClients) RemoveClient(url string) {
 
 type Client interface {
 	Client() *nodeclient.Client
-	Indexer() (nodeclient.IndexerClient, error)
+	Indexer(ctx context.Context) (nodeclient.IndexerClient, error)
 	// URL returns a client API url.
 	URL() (cltID string)
 	// PostBlock sends a block to the Tangle via a given client.
-	PostBlock(block *iotago.Block) (iotago.BlockID, error)
+	PostBlock(ctx context.Context, block *iotago.Block) (iotago.BlockID, error)
 	// PostData sends the given data (payload) by creating a block in the backend.
-	PostData(data []byte) (blkID string, err error)
+	PostData(ctx context.Context, data []byte) (blkID string, err error)
 	// GetBlockConfirmationState returns the AcceptanceState of a given block ID.
-	GetBlockConfirmationState(blkID iotago.BlockID) string
+	GetBlockConfirmationState(ctx context.Context, blkID iotago.BlockID) string
 	// GetBlockStateFromTransaction returns the AcceptanceState of a given transaction ID.
-	GetBlockStateFromTransaction(txID iotago.TransactionID) (resp *apimodels.BlockMetadataResponse, err error)
+	GetBlockStateFromTransaction(ctx context.Context, txID iotago.TransactionID) (resp *apimodels.BlockMetadataResponse, err error)
 	// GetOutput gets the output of a given outputID.
-	GetOutput(outputID iotago.OutputID) iotago.Output
+	GetOutput(ctx context.Context, outputID iotago.OutputID) iotago.Output
 	// GetOutputConfirmationState gets the first unspent outputs of a given address.
-	GetOutputConfirmationState(outputID iotago.OutputID) string
+	GetOutputConfirmationState(ctx context.Context, outputID iotago.OutputID) string
 	// GetTransaction gets the transaction.
-	GetTransaction(txID iotago.TransactionID) (resp *iotago.SignedTransaction, err error)
+	GetTransaction(ctx context.Context, txID iotago.TransactionID) (resp *iotago.SignedTransaction, err error)
 	// GetBlockIssuance returns the latest commitment and data needed to create a new block.
-	GetBlockIssuance(...iotago.SlotIndex) (resp *apimodels.IssuanceBlockHeaderResponse, err error)
+	GetBlockIssuance(ctx context.Context, slots ...iotago.SlotIndex) (resp *apimodels.IssuanceBlockHeaderResponse, err error)
 	// GetCongestion returns congestion data such as rmc or issuing readiness.
-	GetCongestion(id iotago.AccountID) (resp *apimodels.CongestionResponse, err error)
+	GetCongestion(ctx context.Context, id iotago.AccountID) (resp *apimodels.CongestionResponse, err error)
 	// RequestFaucetFunds
-	RequestFaucetFunds(address iotago.Address) (err error)
+	RequestFaucetFunds(ctx context.Context, address iotago.Address) (err error)
 
 	iotago.APIProvider
 }
@@ -235,8 +235,8 @@ func (c *WebClient) Client() *nodeclient.Client {
 	return c.client
 }
 
-func (c *WebClient) Indexer() (nodeclient.IndexerClient, error) {
-	return c.client.Indexer(context.Background())
+func (c *WebClient) Indexer(ctx context.Context) (nodeclient.IndexerClient, error) {
+	return c.client.Indexer(ctx)
 }
 
 func (c *WebClient) APIForVersion(version iotago.Version) (iotago.API, error) {
@@ -279,8 +279,8 @@ func NewWebClient(url, faucetURL string, opts ...options.Option[WebClient]) (*We
 	}), initErr
 }
 
-func (c *WebClient) RequestFaucetFunds(address iotago.Address) (err error) {
-	req, err := http.NewRequestWithContext(context.Background(), http.MethodPost, c.faucetURL+"/api/enqueue", func() io.Reader {
+func (c *WebClient) RequestFaucetFunds(ctx context.Context, address iotago.Address) (err error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.faucetURL+"/api/enqueue", func() io.Reader {
 		jsonData, _ := json.Marshal(&faucet.EnqueueRequest{
 			Address: address.Bech32(c.client.CommittedAPI().ProtocolParameters().Bech32HRP()),
 		})
@@ -306,12 +306,12 @@ func (c *WebClient) RequestFaucetFunds(address iotago.Address) (err error) {
 	return nil
 }
 
-func (c *WebClient) PostBlock(block *iotago.Block) (blockID iotago.BlockID, err error) {
-	return c.client.SubmitBlock(context.Background(), block)
+func (c *WebClient) PostBlock(ctx context.Context, block *iotago.Block) (blockID iotago.BlockID, err error) {
+	return c.client.SubmitBlock(ctx, block)
 }
 
 // PostData sends the given data (payload) by creating a block in the backend.
-func (c *WebClient) PostData(data []byte) (blkID string, err error) {
+func (c *WebClient) PostData(ctx context.Context, data []byte) (blkID string, err error) {
 	blockBuilder := builder.NewBasicBlockBuilder(c.client.CommittedAPI())
 	blockBuilder.IssuingTime(time.Time{})
 
@@ -324,7 +324,7 @@ func (c *WebClient) PostData(data []byte) (blkID string, err error) {
 		return iotago.EmptyBlockID.ToHex(), err
 	}
 
-	id, err := c.client.SubmitBlock(context.Background(), blk)
+	id, err := c.client.SubmitBlock(ctx, blk)
 	if err != nil {
 		return
 	}
@@ -333,9 +333,9 @@ func (c *WebClient) PostData(data []byte) (blkID string, err error) {
 }
 
 // GetOutputConfirmationState gets the first unspent outputs of a given address.
-func (c *WebClient) GetOutputConfirmationState(outputID iotago.OutputID) string {
+func (c *WebClient) GetOutputConfirmationState(ctx context.Context, outputID iotago.OutputID) string {
 	txID := outputID.TransactionID()
-	resp, err := c.GetBlockStateFromTransaction(txID)
+	resp, err := c.GetBlockStateFromTransaction(ctx, txID)
 	if err != nil {
 		return ""
 	}
@@ -344,8 +344,8 @@ func (c *WebClient) GetOutputConfirmationState(outputID iotago.OutputID) string 
 }
 
 // GetOutput gets the output of a given outputID.
-func (c *WebClient) GetOutput(outputID iotago.OutputID) iotago.Output {
-	res, err := c.client.OutputByID(context.Background(), outputID)
+func (c *WebClient) GetOutput(ctx context.Context, outputID iotago.OutputID) iotago.Output {
+	res, err := c.client.OutputByID(ctx, outputID)
 	if err != nil {
 		return nil
 	}
@@ -354,8 +354,8 @@ func (c *WebClient) GetOutput(outputID iotago.OutputID) iotago.Output {
 }
 
 // GetBlockConfirmationState returns the AcceptanceState of a given block ID.
-func (c *WebClient) GetBlockConfirmationState(blkID iotago.BlockID) string {
-	resp, err := c.client.BlockMetadataByBlockID(context.Background(), blkID)
+func (c *WebClient) GetBlockConfirmationState(ctx context.Context, blkID iotago.BlockID) string {
+	resp, err := c.client.BlockMetadataByBlockID(ctx, blkID)
 	if err != nil {
 		return ""
 	}
@@ -364,13 +364,13 @@ func (c *WebClient) GetBlockConfirmationState(blkID iotago.BlockID) string {
 }
 
 // GetBlockStateFromTransaction returns the AcceptanceState of a given transaction ID.
-func (c *WebClient) GetBlockStateFromTransaction(txID iotago.TransactionID) (*apimodels.BlockMetadataResponse, error) {
-	return c.client.TransactionIncludedBlockMetadata(context.Background(), txID)
+func (c *WebClient) GetBlockStateFromTransaction(ctx context.Context, txID iotago.TransactionID) (*apimodels.BlockMetadataResponse, error) {
+	return c.client.TransactionIncludedBlockMetadata(ctx, txID)
 }
 
 // GetTransaction gets the transaction.
-func (c *WebClient) GetTransaction(txID iotago.TransactionID) (tx *iotago.SignedTransaction, err error) {
-	resp, err := c.client.TransactionIncludedBlock(context.Background(), txID)
+func (c *WebClient) GetTransaction(ctx context.Context, txID iotago.TransactionID) (tx *iotago.SignedTransaction, err error) {
+	resp, err := c.client.TransactionIncludedBlock(ctx, txID)
 	if err != nil {
 		return
 	}
@@ -385,10 +385,10 @@ func (c *WebClient) GetTransaction(txID iotago.TransactionID) (tx *iotago.Signed
 	return tx, nil
 }
 
-func (c *WebClient) GetBlockIssuance(slotIndex ...iotago.SlotIndex) (resp *apimodels.IssuanceBlockHeaderResponse, err error) {
-	return c.client.BlockIssuance(context.Background(), slotIndex...)
+func (c *WebClient) GetBlockIssuance(ctx context.Context, slotIndex ...iotago.SlotIndex) (resp *apimodels.IssuanceBlockHeaderResponse, err error) {
+	return c.client.BlockIssuance(ctx, slotIndex...)
 }
 
-func (c *WebClient) GetCongestion(accountID iotago.AccountID) (resp *apimodels.CongestionResponse, err error) {
-	return c.client.Congestion(context.Background(), accountID)
+func (c *WebClient) GetCongestion(ctx context.Context, accountID iotago.AccountID) (resp *apimodels.CongestionResponse, err error) {
+	return c.client.Congestion(ctx, accountID)
 }

--- a/pkg/spammer/options.go
+++ b/pkg/spammer/options.go
@@ -40,7 +40,7 @@ func WithSpamDuration(maxDuration time.Duration) Options {
 
 // WithSpammingFunc sets core function of the spammer with spamming logic, needs to use done spammer's channel to communicate.
 // end of spamming and errors. Default one is the CustomConflictSpammingFunc.
-func WithSpammingFunc(spammerFunc func(s *Spammer)) Options {
+func WithSpammingFunc(spammerFunc SpammingFunc) Options {
 	return func(s *Spammer) {
 		s.spammingFunc = spammerFunc
 	}

--- a/pkg/spammer/spammer.go
+++ b/pkg/spammer/spammer.go
@@ -217,7 +217,7 @@ func (s *Spammer) Spam(ctx context.Context) {
 					goroutineCount.Inc()
 					defer goroutineCount.Dec()
 
-					err := s.spammingFunc(ctx, s)
+					err := s.spammingFunc(newContext, s)
 					// currently we stop the spammer when there's no fresh faucet outputs.
 					if ierrors.Is(err, evilwallet.NoFreshOutputsAvailable) {
 						s.failed <- true

--- a/programs/dispatcher.go
+++ b/programs/dispatcher.go
@@ -1,6 +1,8 @@
 package programs
 
 import (
+	"context"
+
 	"github.com/iotaledger/evil-tools/pkg/accountwallet"
 	"github.com/iotaledger/evil-tools/pkg/models"
 )
@@ -22,10 +24,10 @@ func NewDispatcher(accWallet *accountwallet.AccountWallet) *Dispatcher {
 	}
 }
 
-func (d *Dispatcher) RunSpam(params *CustomSpamParams) {
+func (d *Dispatcher) RunSpam(ctx context.Context, params *CustomSpamParams) {
 	// todo custom spam should return a spammer instance, and the process should run in the background
 	// or we could inject channel to be able to stop the spammer
-	CustomSpam(params, d.accWallet)
+	CustomSpam(ctx, params, d.accWallet)
 
 	d.activeSpammers = append(d.activeSpammers, &Runner{
 		finished:    make(chan bool),


### PR DESCRIPTION
Close #5 

* Propagate context through goroutines in order to terminate the spammer properly.
* Terminate the spammer if there's no fresh outputs available.
* Terminate the spammer if requesting faucet funds failed at the start.
* Minor refactors.