### PR TITLE
Fix spammer stopping after first wallet

### DIFF
--- a/pkg/accountwallet/faucet.go
+++ b/pkg/accountwallet/faucet.go
@@ -23,7 +23,6 @@ const (
 )
 
 func (a *AccountWallet) RequestBlockBuiltData(ctx context.Context, clt models.Client, account wallet.Account) (*api.CongestionResponse, *api.IssuanceBlockHeaderResponse, iotago.Version, error) {
-	// TODO this should be later remove after congestion for implicit account will work
 	issuerResp, err := clt.GetBlockIssuance(ctx)
 	if err != nil {
 		return nil, nil, 0, ierrors.Wrapf(err, "failed to get block issuance data for accID %s, addr %s", account.ID().ToHex(), account.Address().String())

--- a/pkg/evilwallet/evilwallet.go
+++ b/pkg/evilwallet/evilwallet.go
@@ -383,18 +383,8 @@ func (e *EvilWallet) matchInputsWithAliases(buildOptions *Options) (inputs []*mo
 	for inputAlias := range buildOptions.aliasInputs {
 		in, ok := e.aliasManager.GetInput(inputAlias)
 		if !ok {
-			w, err2 := e.useFreshIfInputWalletNotProvided(buildOptions)
-			if err2 != nil {
-				err = err2
-				return
-			}
-
-			if w == nil {
-				return nil, NoFreshOutputsAvailable
-			}
-
 			// No output found for given alias, use internal Fresh output if wallets are non-empty.
-			in = w.GetUnspentOutput()
+			in = buildOptions.inputWallet.GetUnspentOutput()
 			if in == nil {
 				return nil, NoFreshOutputsAvailable
 			}

--- a/pkg/evilwallet/evilwallet.go
+++ b/pkg/evilwallet/evilwallet.go
@@ -278,7 +278,7 @@ func (e *EvilWallet) CreateTransaction(ctx context.Context, options ...Option) (
 	return issuanceData, nil
 }
 
-// addOutputsToOutputManager adds output to the OutputManager if.
+// addOutputsToOutputManager adds output to the OutputManager.
 func (e *EvilWallet) addOutputsToOutputManager(outputs []iotago.Output, outWallet, tmpWallet *Wallet, tempAddresses map[string]types.Empty) []*models.Output {
 	modelOutputs := make([]*models.Output, 0)
 	for _, out := range outputs {
@@ -318,8 +318,8 @@ func (e *EvilWallet) updateInputWallet(buildOptions *Options) error {
 
 		break
 	}
+	// assign fresh wallet that will be used when only aliases were provided
 	w, err := e.useFreshIfInputWalletNotProvided(buildOptions)
-
 	if err != nil {
 		return err
 	}
@@ -346,12 +346,13 @@ func (e *EvilWallet) registerOutputAliases(outputs []*models.Output, idAliasMap 
 }
 
 func (e *EvilWallet) prepareInputs(buildOptions *Options) (inputs []*models.Output, err error) {
+	// case 1, inputs provided
 	if buildOptions.areInputsProvidedWithoutAliases() {
 		inputs = append(inputs, buildOptions.inputs...)
 
 		return
 	}
-	// append inputs with alias
+	// case 2, no inputs, there has to be aliases provided
 	aliasInputs, err := e.matchInputsWithAliases(buildOptions)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
fixes : #31  
Error was caused due to mismatch in the last index spent vs used, as both indexes start from 0, not -1, both of them should be assigned with firstly reading then increasing the value.